### PR TITLE
Add UnfoldRight and UnfoldLeft for Lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 build
 *.log
 .#*.*
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ bin
 build
 *.log
 .#*.*
-.DS_Store

--- a/src/fp/list.nim
+++ b/src/fp/list.nim
@@ -101,7 +101,7 @@ proc foldLeft*[T,U](xs: List[T], z: U, f: (U, T) -> U): U =
 
 # foldRight can be recursive, or realized via foldLeft.
 proc foldRight*[T,U](xs: List[T], z: U, f: (T, U) -> U): U =
-  ## Fold right operation. Can be defined via foldLeft (-d:foldRightViaLeft switch), or be recursive bu default.
+  ## Fold right operation. Can be defined via foldLeft (-d:foldRightViaLeft switch), or be recursive by default.
   when defined(foldRightViaLeft):
     foldLeft[T, U -> U](xs, (b: U) => b, (g: U -> U, x: T) => ((b: U) => g(f(x, b))))(z)
   else:
@@ -113,6 +113,24 @@ proc foldRightF*[T, U](xs: List[T], z: () -> U, f: (T, () -> U) -> U): U =
   ## Right fold over lists. Lazy in accumulator - allows for early termination.
   if xs.isEmpty: z()
   else: f(xs.head, () => xs.tail.foldRightF(z, f))
+
+proc unfoldLeft*[T](f: T -> Option[(T, T)], x:T): List[T] {. inline .}=
+    ## Build a List from the left from function f: T -> Option(T,T) and a seed of type T
+    result = Nil[T]()
+    var a, b = x
+
+    while f(a).isDefined():
+        (b, a) = f(a).get()
+        result = b ^^ result
+
+proc unfoldRight*[T](f: T -> Option[(T, T)], x:T): List[T] {. inline .}=
+    ## Build a List from the right from function f: T -> Option(T,T) and a seed of type T
+    result = Nil[T]()
+    var a, b = x
+
+    while f(a).isDefined():
+        (b, a) = f(a).get()
+        result = result.append(b.asList)
 
 proc drop*(xs: List, n: int): List =
   ## Drops `n` first elements of the list

--- a/src/fp/list.nim
+++ b/src/fp/list.nim
@@ -114,23 +114,22 @@ proc foldRightF*[T, U](xs: List[T], z: () -> U, f: (T, () -> U) -> U): U =
   if xs.isEmpty: z()
   else: f(xs.head, () => xs.tail.foldRightF(z, f))
 
-proc unfoldLeft*[T](f: T -> Option[(T, T)], x:T): List[T] {. inline .}=
+# After bug https://github.com/nim-lang/Nim/issues/5647, remove item and seed from type signature
+proc unfoldLeft*[T, U](f: U -> Option[tuple[item: T, seed: U]], x:U): List[T] {. inline .}=
     ## Build a List from the left from function f: T -> Option(T,T) and a seed of type T
     result = Nil[T]()
-    var a, b = x
+    var a = x
+    var b: T
 
-    while f(a).isDefined():
-        (b, a) = f(a).get()
+    var fa = f(a)
+    while fa.isDefined:
+        (b, a) = fa.get()
         result = b ^^ result
+        fa = f(a)
 
-proc unfoldRight*[T](f: T -> Option[(T, T)], x:T): List[T] {. inline .}=
+proc unfoldRight*[T, U](f: U -> Option[tuple[item: T, seed: U]], x:U): List[T] {. inline .}=
     ## Build a List from the right from function f: T -> Option(T,T) and a seed of type T
-    result = Nil[T]()
-    var a, b = x
-
-    while f(a).isDefined():
-        (b, a) = f(a).get()
-        result = result.append(b.asList)
+    unfoldLeft(f,x).reverse
 
 proc drop*(xs: List, n: int): List =
   ## Drops `n` first elements of the list

--- a/tests/fp/test_list.nim
+++ b/tests/fp/test_list.nim
@@ -32,6 +32,19 @@ suite "List ADT":
 
     check: Nil[int]().foldRight(100, (x, y) => x + y) == 100
 
+  test "Unfold operations":
+    proc divmod10(n: int): Option[(int, int)] =
+      if n == 0:
+          return none((int,int))
+      return some(( (n mod 10).int, n div 10))
+
+    proc toDigits(n: int): List[int] = unfoldLeft(divmod10,n)
+    proc toReversedDigits(n: int): List[int] = unfoldRight(divmod10,n)
+
+    let n = 12301230
+    check: toDigits(n) == [1,2,3,0,1,2,3,0].asList
+    check: toReversedDigits(n) == [0,3,2,1,0,3,2,1].asList
+
   test "Transformations":
     check: @[1, 2, 3].asList.traverse((x: int) => x.some) == @[1, 2, 3].asList.some
     check: @[1, 2, 3].asList.traverse((x: int) => (if x > 2: x.none else: x.some)) == List[int].none

--- a/tests/fp/test_list.nim
+++ b/tests/fp/test_list.nim
@@ -45,6 +45,23 @@ suite "List ADT":
     check: toDigits(n) == [1,2,3,0,1,2,3,0].asList
     check: toReversedDigits(n) == [0,3,2,1,0,3,2,1].asList
 
+    let vowels: List[char] = ['a','e','i','o','u','y', 'A', 'E', 'I', 'O', 'U', 'Y'].asList
+    let s = "Is it a success?"
+
+    proc isHeadVowel(s: string): (Option[((char,bool), string)]) =
+      if s == "":
+        return none(((char,bool),string))
+      return some(
+        ((s[0],vowels.contains(s[0])), s[1..^1])
+        )
+    proc vowelToTrue(s: string): List[(char, bool)] = unfoldLeft(isHeadVowel,s)
+    proc vowelToTrueReversed(s: string): List[(char, bool)] = unfoldRight(isHeadVowel,s)
+
+    when compiles(vowelToTrue(s)):
+      check: true
+    when compiles(vowelToTrueReversed(s)):
+      check: true
+
   test "Transformations":
     check: @[1, 2, 3].asList.traverse((x: int) => x.some) == @[1, 2, 3].asList.some
     check: @[1, 2, 3].asList.traverse((x: int) => (if x > 2: x.none else: x.some)) == List[int].none

--- a/tests/fp/test_list.nim
+++ b/tests/fp/test_list.nim
@@ -34,33 +34,29 @@ suite "List ADT":
 
   test "Unfold operations":
     proc divmod10(n: int): Option[(int, int)] =
-      if n == 0:
-          return none((int,int))
-      return some(( (n mod 10).int, n div 10))
+      if n == 0: none((int,int))
+      else: some(( (n mod 10).int, n div 10))
 
-    proc toDigits(n: int): List[int] = unfoldLeft(divmod10,n)
-    proc toReversedDigits(n: int): List[int] = unfoldRight(divmod10,n)
+    check: unfoldLeft(divmod10,12301230) == [1,2,3,0,1,2,3,0].asList
+    check: unfoldRight(divmod10,12301230) == [0,3,2,1,0,3,2,1].asList
 
-    let n = 12301230
-    check: toDigits(n) == [1,2,3,0,1,2,3,0].asList
-    check: toReversedDigits(n) == [0,3,2,1,0,3,2,1].asList
-
-    let vowels: List[char] = ['a','e','i','o','u','y', 'A', 'E', 'I', 'O', 'U', 'Y'].asList
-    let s = "Is it a success?"
-
-    proc isHeadVowel(s: string): (Option[((char,bool), string)]) =
-      if s == "":
-        return none(((char,bool),string))
-      return some(
-        ((s[0],vowels.contains(s[0])), s[1..^1])
-        )
-    proc vowelToTrue(s: string): List[(char, bool)] = unfoldLeft(isHeadVowel,s)
-    proc vowelToTrueReversed(s: string): List[(char, bool)] = unfoldRight(isHeadVowel,s)
-
-    when compiles(vowelToTrue(s)):
-      check: true
-    when compiles(vowelToTrueReversed(s)):
-      check: true
+    proc unconsString(s: string): Option[(char, string)] =
+      if s == "": none((char, string))
+      else: some((s[0], s[1..^1]))
+    
+    check: unfoldLeft(unconsString,"Success !") == ['!', ' ', 's', 's', 'e', 'c', 'c', 'u', 'S'].asList
+    check: unfoldRight(unconsString,"Success !") == ['S', 'u', 'c', 'c', 'e', 's', 's', ' ', '!'].asList
+    
+    var global_count: int = 0
+    proc divmod10_count(n: int): Option[(int, int)] =
+      inc global_count
+      if n == 0: none((int,int))
+      else: some(( (n mod 10).int, n div 10))
+      
+    let _ = unfoldLeft(divmod10_count,12301230)
+    check: global_count == 9
+    let _ = unfoldRight(divmod10_count,12301230)
+    check: global_count == 18
 
   test "Transformations":
     check: @[1, 2, 3].asList.traverse((x: int) => x.some) == @[1, 2, 3].asList.some


### PR DESCRIPTION
Hello vegansk.

Here is a PR for `UnfoldRight` and `UnfoldLeft` functions

I've also written two accompagnying tests:
Splitting 12301230 into its digits in normal order (unfoldLeft) and reverse order (unfoldRight)

I've added the `{. inline .}` pragma as Haskell as a [really long comment](https://hackage.haskell.org/package/base-4.9.1.0/docs/src/Data.OldList.html#unfoldr) about it.

I don't have a benchmark to check performance on Nim though.

```Haskell-- Note [INLINE unfoldr]
-- We treat unfoldr a little differently from some other forms for list fusion
-- for two reasons:
--
-- 1. We don't want to use a rule to rewrite a basic form to a fusible
-- form because this would inline before constant floating. As Simon Peyton-
-- Jones and others have pointed out, this could reduce sharing in some cases
-- where sharing is beneficial. Thus we simply INLINE it, which is, for
-- example, how enumFromTo::Int becomes eftInt. Unfortunately, we don't seem
-- to get enough of an inlining discount to get a version of eftInt based on
-- unfoldr to inline as readily as the usual one. We know that all the Maybe
-- nonsense will go away, but the compiler does not.
--
-- 2. The benefit of inlining unfoldr is likely to be huge in many common cases,
-- even apart from list fusion. In particular, inlining unfoldr often
-- allows GHC to erase all the Maybes. This appears to be critical if unfoldr
-- is to be used in high-performance code. A small increase in code size
-- in the relatively rare cases when this does not happen looks like a very
-- small price to pay.
--
-- Doing a back-and-forth dance doesn't seem to accomplish anything if the
-- final form has to be inlined in any case.
```
