### PR TITLE
WIP: Add template versions of functions

### DIFF
--- a/src/fp/either.nim
+++ b/src/fp/either.nim
@@ -108,6 +108,21 @@ proc flatMap*[E,A,B](e: Either[E,A], f: A -> Either[E,B]): Either[E,B] =
   ## Returns the result of applying `f` to the right value or returns left value
   if e.isLeft: e.lValue.left(B) else: f(e.rValue)
 
+template flatMapIt*(e: Either, op: untyped): untyped =
+  type outType = type((
+    block:
+    var it{.inject.}: e.elemType;
+    op))
+
+  var result: Either[e.leftElemType, e.elemType]
+
+  if e.isLeft:
+    result = e.lValue.left(type(e.elemType))
+  else:
+    let it {.inject.} = e.rValue
+    result = op
+  result
+
 proc get*[E,A](e: Either[E,A]): A =
   ## Returns either's value if it is right, or fail
   doAssert(e.isRight, "Can't get Either's value")
@@ -343,6 +358,9 @@ proc asList*[E,A](e: Either[E,A]): List[A] =
 template elemType*(v: Either): typedesc =
   ## Part of ``do notation`` contract
   type(v.get)
+
+template leftElemType*(v: Either): typedesc =
+  type(v.getLeft)
 
 proc point*[E,A](v: A, e: typedesc[Either[E,A]]): Either[E,A] =
   v.right(E)

--- a/src/fp/option.nim
+++ b/src/fp/option.nim
@@ -89,6 +89,21 @@ proc flatMap*[T,U](o: Option[T], f: T -> Option[U]): Option[U] =
   ## Returns the result of applying `f` if `o` is defined, or none
   if o.isDefined: f(o.value) else: none(U)
 
+template flatMapIt*(o: Option, op: untyped): untyped =
+  type outType = type((
+    block:
+    var it{.inject.}: o.elemType;
+    op))
+
+  var result: Option[o.elemType]
+
+  if o.isDefined:
+    let it {.inject.} = o.get
+    result = op
+  else:
+    result = none(type(o.elemType))
+  result
+
 proc join*[T](mmt: Option[Option[T]]): Option[T] =
   ## Flattens the option
   mmt.flatMap(id)

--- a/tests/fp/test_either.nim
+++ b/tests/fp/test_either.nim
@@ -80,6 +80,9 @@ suite "Either ADT":
     check: r.flatMap((x: int) => (x * 2).rightS) == 20.rightS
     check: r.flatMap((x: int) => l) == l
 
+    check: r.flatMapIt((it * 2).rightS) == 20.rightS
+    check: r.flatMapIt(l) == l
+
     check: "Value".rightS.map2(10.rightS, (x: string, y: int) => x & $y) == "Value10".rightS
     check: "Error1".left(string).map2(10.rightS, (x: string, y: int) => x & $y) == "Error1".left(string)
     check: "Value".rightS.map2("Error2".left(int), (x: string, y: int) => x & $y) == "Error2".left(string)

--- a/tests/fp/test_option.nim
+++ b/tests/fp/test_option.nim
@@ -53,6 +53,8 @@ suite "Option ADT":
     check: 2.some.flatMap(f) == some(4)
     check: 2.none.flatMap(f) == none(4)
 
+    check: 2.some.flatMapIt(it * 2) == some(4)
+
   test "Join":
     check: 2.some.some.join == 2.some
     check: int.none.some.join == int.none


### PR DESCRIPTION
Reason: in templates, we can use type inference, and so instead of writing 
```nim
r.flatMap((x: int) => (x * 2).rightS)
```
, we can write 
```nim
r.flatMapIt((it * 2).rightS)
```